### PR TITLE
Make subsequent clicks cycle between candidate parcels

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -48,12 +48,24 @@ map.addControl(
     map.on("load", () => {
       setTheMap(map);
       map.on("click", "parcels-fill", function (e) {
-        let parcel = map.queryRenderedFeatures(e.point, {
+        let results = map.queryRenderedFeatures(e.point, {
           layers: ["parcels-fill"],
         });
-        console.log(parcel)
-        setParcel(parcel[0].properties.parcelno);
-        history.push(`/${parcel[0].properties.parcelno}/`);
+        console.log(results)
+
+        // Subsequent clicks on the same shape cycle between overlapping parcels.
+        setParcel((currentParcel) => {
+          const parcels = results.map((p) => p.properties.parcelno)
+          const currentIndex = parcels.findIndex((candidateParcel) =>
+            candidateParcel === currentParcel
+          );
+          const nextIndex = (currentIndex + 1) % results.length;
+          const nextParcel = parcels[nextIndex];
+
+          history.push(`/${nextParcel}/`);
+          return nextParcel;
+        });
+
         // setCoords(e.lngLat);
       });
 

--- a/src/tailwind.output.css
+++ b/src/tailwind.output.css
@@ -863,10 +863,6 @@ video {
   padding-left: 0.25rem;
 }
 
-.static{
-  position: static;
-}
-
 .absolute{
   position: absolute;
 }


### PR DESCRIPTION
Closes #5

### How to test
1. Pull down the branch
2. Find a lot with multiple parcels that overlap. I used 434 West Alexandrine for testing. 
3. Click multiple times on the same parcel

**In production**: You're only able to select the first parcel result, which is the big outer shape.
**On this branch**: On subsequent clicks, you cycle between the big outer shape and the smaller inner shapes.

For a video demo, see https://share.getcloudapp.com/Jruxy7yO